### PR TITLE
links -> depends_on

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build: .
     ports:
       - 8000:8000
-    links:
+    depends_on:
       - mariadb
       - chromedp
     volumes:


### PR DESCRIPTION
[links](https://docs.docker.com/compose/compose-file/#links) is a deprecated legacy feature, use [depends_on](https://docs.docker.com/compose/compose-file/#depends_on) instead.